### PR TITLE
Wording to enable clients to request Idempotency

### DIFF
--- a/draft-ietf-httpapi-idempotency-key-header.md
+++ b/draft-ietf-httpapi-idempotency-key-header.md
@@ -107,6 +107,8 @@ Client
 
 Clients of HTTP API requiring idempotency, SHOULD understand the idempotency related requirements as published by the server and use appropriate algorithm to generate idempotency keys.
 
+Clients MAY choose to send an Idempotency-Key field with any valid random sf-string to indicate the user's intent is to only perform this action once. Without a priori knowledge, a general client cannot assume the server will respect this request.
+
 For each request, client SHOULD
 
 * Send a unique idempotency key in the HTTP `Idempotency-Key` request header field.


### PR DESCRIPTION
This is a PR that attempts to capture the suggestions made in this thread https://mailarchive.ietf.org/arch/msg/httpapi/xPXzwNNFyjNjmqzNcJjLDIhOK_o/

The general idea is that generic clients can choose to send Idempotency-Key if they believe that the user would benefit from the request being idempotent without any knowledge of whether the supports the Idempotency-Key header.